### PR TITLE
Add Souto Costa server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ These servers aim to demonstrate MCP features and the TypeScript and Python SDKs
 - **[Sentry](src/sentry)** - Retrieving and analyzing issues from Sentry.io
 - **[Sequential Thinking](src/sequentialthinking)** - Dynamic and reflective problem-solving through thought sequences
 - **[Slack](src/slack)** - Channel management and messaging capabilities
+- **[Souto Costa](src/souto-costa)** - Consulta online de processos para clientes
 - **[Sqlite](src/sqlite)** - Database interaction and business intelligence capabilities
 - **[Time](src/time)** - Time and timezone conversion capabilities
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@modelcontextprotocol/server-memory": "*",
     "@modelcontextprotocol/server-filesystem": "*",
     "@modelcontextprotocol/server-everart": "*",
-    "@modelcontextprotocol/server-sequential-thinking": "*"
+    "@modelcontextprotocol/server-sequential-thinking": "*",
+    "@modelcontextprotocol/server-souto-costa": "*"
   }
 }

--- a/src/souto-costa/README.md
+++ b/src/souto-costa/README.md
@@ -1,0 +1,25 @@
+# Souto Costa - Consulta de Processos
+
+Pequeno servidor Express para que clientes acompanhem o andamento de seus processos online.
+
+## Endpoints
+
+- `GET /processos` - Lista todos os processos cadastrados.
+- `GET /processos/:id` - Retorna detalhes de um processo específico.
+
+## Como executar
+
+Instale as dependências e compile o servidor:
+
+```bash
+npm install
+npm run --workspace ./src/souto-costa build
+```
+
+Em seguida execute:
+
+```bash
+node src/souto-costa/dist/index.js
+```
+
+O servidor será iniciado na porta `3000` por padrão.

--- a/src/souto-costa/index.ts
+++ b/src/souto-costa/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import express from 'express';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+interface Processo {
+  id: number;
+  cliente: string;
+  descricao: string;
+  status: string;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataPath = process.env.PROCESS_FILE || path.join(__dirname, 'processos.json');
+
+async function loadProcessos(): Promise<Processo[]> {
+  try {
+    const data = await fs.readFile(dataPath, 'utf-8');
+    return JSON.parse(data) as Processo[];
+  } catch {
+    return [];
+  }
+}
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/processos', async (_req, res) => {
+  const processos = await loadProcessos();
+  res.json(processos);
+});
+
+app.get('/processos/:id', async (req, res) => {
+  const processos = await loadProcessos();
+  const id = Number(req.params.id);
+  const processo = processos.find(p => p.id === id);
+  if (processo) {
+    res.json(processo);
+  } else {
+    res.status(404).json({ erro: 'Processo n\u00e3o encontrado' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Servidor Souto Costa rodando na porta ${port}`);
+});

--- a/src/souto-costa/package.json
+++ b/src/souto-costa/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@modelcontextprotocol/server-souto-costa",
+  "version": "0.1.0",
+  "description": "Servidor simples para consulta de processos do escritório Souto Costa",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "souto-costa-server": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && shx chmod +x dist/*.js",
+    "prepare": "npm run build",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "express": "^4.21.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22",
+    "shx": "^0.3.4",
+    "typescript": "^5.6.2"
+  }
+}

--- a/src/souto-costa/processos.json
+++ b/src/souto-costa/processos.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "cliente": "Jo\u00e3o Silva", "descricao": "A\u00e7\u00e3o trabalhista", "status": "Em andamento"},
+  {"id": 2, "cliente": "Maria Souza", "descricao": "Processo civil", "status": "Conclu\u00eddo"},
+  {"id": 3, "cliente": "Pedro Santos", "descricao": "Revis\u00e3o de contrato", "status": "Aguardando audi\u00eancia"}
+]

--- a/src/souto-costa/tsconfig.json
+++ b/src/souto-costa/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- implement a new server `src/souto-costa` with a basic Express API for process consultation
- document the server in the main README and as a workspace dependency

## Testing
- `npm run --workspace ./src/souto-costa build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6871d0d0d0788330ac84dc351c765bc9